### PR TITLE
add `mcp-server-box` script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
+scripts = { "mcp-server-box" = "mcp_server_box:main" }
 dependencies = [
     "box-ai-agents-toolkit>=0.0.42",
     "box-sdk-gen>=1.13.0",

--- a/src/mcp_server_box.py
+++ b/src/mcp_server_box.py
@@ -888,6 +888,11 @@ def _serialize(obj):
         # If all else fails, convert to string
         return str(obj)
 
-if __name__ == "__main__":
+
+def main():
     # Initialize and run the server
     mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This server can be launched directly using `uvx` without downloading the source code manually.

```
uvx  git+https://github.com/box-community/mcp-server-box.git
```