### PR TITLE
fix agent_id error on several box ai tools

### DIFF
--- a/src/box_tools_ai.py
+++ b/src/box_tools_ai.py
@@ -16,7 +16,7 @@ from box_tools_generic import get_box_client
 
 
 async def box_ai_ask_file_single_tool(
-    ctx: Context, file_id: str, prompt: str, ai_agent_id: Optional[str]
+    ctx: Context, file_id: str, prompt: str, ai_agent_id: Optional[str] = None
 ) -> dict:
     """
     Ask Box AI about a single file.
@@ -38,7 +38,7 @@ async def box_ai_ask_file_single_tool(
 
 
 async def box_ai_ask_file_multi_tool(
-    ctx: Context, file_ids: List[str], prompt: str, ai_agent_id: Optional[str]
+    ctx: Context, file_ids: List[str], prompt: str, ai_agent_id: Optional[str] = None
 ) -> dict:
     """
     Ask Box AI about multiple files.
@@ -59,7 +59,7 @@ async def box_ai_ask_file_multi_tool(
 
 
 async def box_ai_ask_hub_tool(
-    ctx: Context, hubs_id: str, prompt: str, ai_agent_id: Optional[str]
+    ctx: Context, hubs_id: str, prompt: str, ai_agent_id: Optional[str] = None
 ) -> dict:
     """
     Ask Box AI about a specific hub.


### PR DESCRIPTION
The following tools in **box_tools_ai.py** had `ai_agent_id: Optional[str]` in their method signatures, but were showing up as required in MCP clients. Added the missing `= None` to fix it.
* **box_ai_ask_file_single_tool**
* **box_ai_ask_file_multi_tool**
* **box_ai_ask_hub_tool**